### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Flutter CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/milaxcoo/Seasons/security/code-scanning/1](https://github.com/milaxcoo/Seasons/security/code-scanning/1)

To fix this issue, the workflow should explicitly set the `permissions` key to restrict the default permissions for the `GITHUB_TOKEN` provided to jobs in this workflow. In this case, only read access to the repository's contents is required, since no steps modify repository data or interact with issues, PRs, etc. The best way to accomplish this is by adding a `permissions: contents: read` block at the top/root of the workflow YAML (directly below the `name:` line and before `on:`). This will enforce least-privilege permissions for all jobs in the workflow and clarify the workflow's required privileges to maintainers and reviewers. No new methods or definitions are required; only one YAML section needs to be inserted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
